### PR TITLE
fix: use ol.proj.fromLonLat in the OL snippet

### DIFF
--- a/src/InfoWidget.js
+++ b/src/InfoWidget.js
@@ -125,7 +125,7 @@ class InfoWidget extends Component {
         ],
         target: 'map',
         view: new ol.View({
-          center: [${center[0]},${center[1]}],
+          center: ol.proj.fromLonLat([${center[0]},${center[1]}]),
           zoom: ${this.props.zoom}
         })
       });


### PR DESCRIPTION
The center is passed as geographical coordinates (WGS84) whereas the View is configured in Web-Mercator